### PR TITLE
Fix for sponsors anchor bug #223

### DIFF
--- a/app/data/menuitems.js
+++ b/app/data/menuitems.js
@@ -16,7 +16,7 @@ export default [
   },
   {
     id: 4,
-    url: '/#partners',
+    url: '/#sponsors',
     label: 'sponsors',
   },
   {


### PR DESCRIPTION
Fix for issue: #223 

Anchor link to "Sponsors was pointing to Partners" .