### PR TITLE
Make menu hash links relative to past editions #189

### DIFF
--- a/app/data/menuitems.js
+++ b/app/data/menuitems.js
@@ -50,11 +50,25 @@ export default [
     id: 1,
     url: '/#speakers',
     label: 'speakers',
+    blacklist: ['/2017', '/2018'],
+  },
+  {
+    id: 1.1,
+    url: '#speakers',
+    label: 'speakers',
+    whitelist: ['/2017', '/2018'],
   },
   {
     id: 2,
+    url: '/#schedule',
+    label: 'schedule',
+    blacklist: ['/2017', '/2018'],
+  },
+  {
+    id: 2.1,
     url: '#schedule',
     label: 'schedule',
+    whitelist: ['/2017', '/2018'],
   },
   {
     id: 3,
@@ -65,6 +79,13 @@ export default [
     id: 4,
     url: '/#sponsors',
     label: 'sponsors',
+    blacklist: ['/2017', '/2018'],
+  },
+  {
+    id: 4.1,
+    url: '#sponsors',
+    label: 'sponsors',
+    whitelist: ['/2017', '/2018'],
   },
   {
     id: 5,


### PR DESCRIPTION
Fixes #189.

The navbar has a few hash links which should be relative to the current route if a past edition is being viewed, otherwise relative to the most recent one.

