### PR TITLE
269: Service Worker Cache Busting and change in Caching Strategy

### DIFF
--- a/offline/dist/serviceWorker.js
+++ b/offline/dist/serviceWorker.js
@@ -1,6 +1,6 @@
 /* eslint no-restricted-globals: 0 */
 
-const VERSION = 'jsheroesio-cache-{{version}}'; // {{version}} will be replaced with a timestamp generated at build time
+const VERSION = 'jsheroesio-cache-1545478225949'; // {{version}} will be replaced with a timestamp generated at build time
 
 // Application Shell
 const urlsToCache = [

--- a/offline/dist/serviceWorker.js
+++ b/offline/dist/serviceWorker.js
@@ -1,6 +1,6 @@
 /* eslint no-restricted-globals: 0 */
 
-const VERSION = 'jsheroesio-cache-1545478225949'; // {{version}} will be replaced with a timestamp generated at build time
+const VERSION = 'jsheroesio-cache-1545557692979'; // will be replaced with a timestamp generated at build time by generateServiceWorker.js
 
 // Application Shell
 const urlsToCache = [

--- a/offline/serviceWorker.js
+++ b/offline/serviceWorker.js
@@ -1,6 +1,6 @@
 /* eslint no-restricted-globals: 0 */
 
-const VERSION = 'jsheroesio-cache-{{version}}'; // {{version}} will be replaced with a timestamp generated at build time
+const VERSION = 'jsheroesio-cache-{{version}}'; // will be replaced with a timestamp generated at build time by generateServiceWorker.js
 
 // Application Shell
 const urlsToCache = [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "linter": "eslint -c config/.eslintrc.json app pages --quiet",
     "dev": "node server.js",
-    "build": "next build",
+    "build": "next build && node scripts/generateServiceWorker.js",
     "start": "NODE_ENV=production node server.js",
     "format": "prettier --config ./config/.prettierrc --ignore-path ./config/.prettierignore --write '**/*.{js,css,md}'",
     "precommit": "lint-staged",

--- a/scripts/generateServiceWorker.js
+++ b/scripts/generateServiceWorker.js
@@ -3,20 +3,54 @@ const fs = require('fs');
 const SW_FILEPATH = `${__dirname}/../offline/serviceWorker.js`;
 const GENERATED_SW_FILEPATH = `${__dirname}/../offline/dist/serviceWorker.js`;
 
-const timestamp = new Date().getTime();
+const isDifferent = (swFileContent, generatedFileContent) => {
+  const content1 = swFileContent.replace(/jsheroesio-cache-{{version}}/i, '');
+  const content2 = generatedFileContent.replace(/jsheroesio-cache-([0-9])+/i, '');
+  return content1 !== content2;
+};
 
-fs.readFile(SW_FILEPATH, 'utf8', (error, content) => {
-  if (error) {
-    console.log(error);
-    return;
-  }
-  const contentWithVersion = content.replace(/{{version}}/, timestamp);
+const generateServiceWorkerFile = (generatedFileContent = null) => {
+  const timestamp = new Date().getTime();
 
-  fs.writeFile(GENERATED_SW_FILEPATH, contentWithVersion, 'utf8', err => {
-    if (err) {
-      console.log(err);
+  fs.readFile(SW_FILEPATH, 'utf8', (readError, swFileContent) => {
+    if (readError) {
+      console.log(readError);
       return;
     }
-    console.log('Service worker updated to new cache version:', timestamp);
+
+    if (generatedFileContent && !isDifferent(swFileContent, generatedFileContent)) {
+      // service worker file has not changed
+      console.log('Service worker file is up to date');
+      return;
+    }
+
+    // add versioning
+    const contentWithVersion = swFileContent.replace(/{{version}}/i, timestamp);
+
+    // save versioned service worker file
+    fs.writeFile(GENERATED_SW_FILEPATH, contentWithVersion, 'utf8', writeError => {
+      if (writeError) {
+        console.log(writeError);
+        return;
+      }
+      console.log('Service worker file updated to new cache version:', timestamp);
+    });
+  });
+};
+
+fs.access(GENERATED_SW_FILEPATH, fs.F_OK, err => {
+  if (err) {
+    // first time generating a sw file
+    generateServiceWorkerFile();
+    return;
+  }
+
+  // we have a previously generated sw file
+  fs.readFile(GENERATED_SW_FILEPATH, 'utf8', (error, generatedFileContent) => {
+    if (error) {
+      console.log(error);
+      return;
+    }
+    generateServiceWorkerFile(generatedFileContent);
   });
 });

--- a/scripts/generateServiceWorker.js
+++ b/scripts/generateServiceWorker.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+const SW_FILEPATH = `${__dirname}/../offline/serviceWorker.js`;
+const GENERATED_SW_FILEPATH = `${__dirname}/../offline/dist/serviceWorker.js`;
+
+const timestamp = new Date().getTime();
+
+fs.readFile(SW_FILEPATH, 'utf8', (error, content) => {
+  if (error) {
+    console.log(error);
+    return;
+  }
+  const contentWithVersion = content.replace(/{{version}}/, timestamp);
+
+  fs.writeFile(GENERATED_SW_FILEPATH, contentWithVersion, 'utf8', err => {
+    if (err) {
+      console.log(err);
+      return;
+    }
+    console.log('Service worker updated to new cache version:', timestamp);
+  });
+});

--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ const startServer = () => {
   });
 
   server.get('/sw.js', (req, res) => {
-    res.sendFile(`${__dirname}/offline/serviceWorker.js`);
+    res.sendFile(`${__dirname}/offline/dist/serviceWorker.js`);
   });
 
   server.get('/workshops/:name', (req, res) => {


### PR DESCRIPTION
Closes #269 

### Notes
* At build time `offline/dist/serviceWorker.js` will be generated if `offline/serviceWorker.js` has changed
* Cache name is no longer hard-coded, a timestamp is appended each time `offline/dist/serviceWorker.js` is generated
* New service worker will take over from the old one in the ACTIVATE event
* Caching strategy "Network falling back to cache" was chosen for some files: online users will get the most up-to-date content, offline users will get an older cached version.

### Screenshots
<img width="1383" alt="screen shot 2018-12-22 at 13 20 47" src="https://user-images.githubusercontent.com/5598081/50382512-d4be6d00-06a9-11e9-893a-85ced9af1da7.png">
<img width="813" alt="screen shot 2018-12-22 at 13 23 08" src="https://user-images.githubusercontent.com/5598081/50382513-d4be6d00-06a9-11e9-871a-d90180b88ded.png">
