### PR TITLE
#289 - Fix W3C warnings for photo gallery

### DIFF
--- a/app/components/photoGallery/index.js
+++ b/app/components/photoGallery/index.js
@@ -59,16 +59,14 @@ const Component = ({ items = getPhotoItems() }) => (
               <source
                 media={`(max-width: ${mediaQueries.XS})`}
                 srcSet={`static/img/photo_gallery/small/${value.src}`}
-                alt=""
               />
               <source
                 media={`(max-width: ${mediaQueries.XL}) and (min-width: ${mediaQueries.XS})`}
                 srcSet={`static/img/photo_gallery/medium/${value.src}`}
-                alt=""
               />
               <img
-                srcSet={`static/img/photo_gallery/large/${value.src}`}
-                alt=""
+                src={`static/img/photo_gallery/large/${value.src}`}
+                alt="gallery item"
                 className="image-wrapper"
               />
             </picture>


### PR DESCRIPTION
Fix #289 

For validating I've used: https://validator.w3.org/

Previous -> https://validator.w3.org/nu/?doc=https%3A%2F%2Fjsheroes.io%2F
(See errors 55-90)
Current (after fix) -> https://validator.w3.org/nu/?doc=https%3A%2F%2Fjsheroesio-gvftcefkvk.now.sh%2F
The errors are gone :-)

