### PR TITLE
fix(lockfile): out of date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4330,7 +4330,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",


### PR DESCRIPTION
File is out of date (apparently, due to a recent issue with the npm registry flipping on and off http->https)