### PR TITLE
Fixed scroll to top on mobile view

### DIFF
--- a/app/components/scroll-btn.js
+++ b/app/components/scroll-btn.js
@@ -39,7 +39,11 @@ class ScrollBtn extends Component {
       <div className={`back-top ${show ? 'show' : ''}`}>
         <a
           className="go-to-anchor"
-          href={`${window.innerWidth}px` <= mediaQueries.S ? '#hero' : '#menu'}
+          href={
+            typeof window !== 'undefined' && `${window.innerWidth}px` <= mediaQueries.S
+              ? '#hero'
+              : '#menu'
+          }
         >
           <i className="fa fa-angle-up" />
         </a>

--- a/app/components/scroll-btn.js
+++ b/app/components/scroll-btn.js
@@ -37,7 +37,10 @@ class ScrollBtn extends Component {
     const { show } = this.state;
     return (
       <div className={`back-top ${show ? 'show' : ''}`}>
-        <a className="go-to-anchor" href="#menu">
+        <a
+          className="go-to-anchor"
+          href={`${window.innerWidth}px` <= mediaQueries.S ? '#hero' : '#menu'}
+        >
           <i className="fa fa-angle-up" />
         </a>
 


### PR DESCRIPTION
On the mobile view, the menu bar is always visible at the top, therefore the scroll to top button has no effect on the page.
I've changed the id of the anchor tag when the mobile view is active in order to scroll to the top of the page.